### PR TITLE
Optimize file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+develop-eggs/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# virtualenv
+.venv/
+venv/

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,10 @@ setup(
         "discord.py>=2.0.0,<3.0.0",
         "urllib3>=1.26.12,<2.0.0",
     ],
-    py_modules=["slack_to_discord"],
+    packages=["slack_to_discord"],
     entry_points={
         "console_scripts": [
-            "slack-to-discord=slack_to_discord:main"
+            "slack-to-discord=slack_to_discord.__main__:main"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
     ],
     install_requires = [
-        "discord.py>=2.0.0,<3.0.0"
+        "discord.py>=2.0.0,<3.0.0",
+        "urllib3>=1.26.12,<2.0.0",
     ],
     py_modules=["slack_to_discord"],
     entry_points={

--- a/slack_to_discord.py
+++ b/slack_to_discord.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 
 import discord
 from discord.errors import Forbidden
+import urllib3
 
 
 # Discord size limits
@@ -69,6 +70,235 @@ GLOBAL_EMOJI_MAP = {
 
 
 __log__ = logging.getLogger(__name__)
+
+
+class IterBuffer:
+    """Provides a buffered readable interface for an iterator"""
+
+    def __init__(self, iterator=None):
+        self.reset(iterator)
+
+    def __len__(self):
+        """How much data is available to be read from the buffer"""
+        return len(self._data) - self._pos
+
+    def _buff_read(self, size=-1):
+        l = len(self)
+        if size < 0 or size > l:
+            size = l
+        if size < 1:
+            return b""
+
+        ret = bytes(self._data if size == l else self._data[self._pos:self._pos+size])
+        self._pos += size
+        return ret
+
+    def _buff_fill(self, size, read1=False):
+        """Ensure enough data is in the buffer"""
+        if size == 0 or self._iter is None:
+            return
+
+        cur_size = len(self)
+        if size > 0 and cur_size >= size:
+            # have the data, don't need to read anything
+            return
+
+        if self._pos > 0:
+            self._data = self._data[self._pos:]
+            self._pos = 0
+
+        for x in self._iter:
+            self._data += x
+            cur_size += len(x)
+            if read1 or (size > 0 and cur_size >= size):
+                break
+        else:
+            self._iter = None
+
+        return
+
+    def relseek(self, num):
+        """Relative seek within the buffer
+
+        Given the number of bytes to seek within the buffer (-/+), get as close
+        as possible and return the actual seek amount
+        """
+        actual = max(-self._pos, min(num, len(self)))
+        self._pos += actual
+        return actual
+
+    def read(self, size=-1):
+        """Read and return up to `size` bytes.
+
+        If the argument is omitted or negative, data is read and returned until
+        EOF is reached. An empty bytes object is returned if the stream is
+        already at EOF
+        """
+        self._buff_fill(size)
+        return self._buff_read(size)
+
+    def read1(self, size=-1):
+        """Read and return up to `size` bytes with at most one call to the iterator"""
+        self._buff_fill(size, read1=True)
+        return self._buff_read(size)
+
+    def reset(self, iterator=None):
+        """Zero out the current buffer and assign a new iterator to buffer bytes from"""
+        self._iter = iterator
+        self._data = bytearray()
+        self._pos = 0
+
+
+class SeekableHTTPStream(io.BufferedIOBase):
+    """Make the contents at a URL addressable via a seekable file-like object.
+
+    Seeking to arbitrary offsets is handled using HTTP range requests.
+
+    Notes:
+     - The server must respond with an `Accept-Ranges: bytes` header for seeking to be supported.
+     - Using `__len__` or `io.SEEK_END` to seek requires the server to have sent a valid `Content-Length` header.
+    """
+
+    def __init__(self, url, chunk_size=64*1024):
+        self._pos = 0
+        self._url = url
+        self._pool = urllib3.PoolManager()
+        self._resp = None
+        self._buff = IterBuffer()
+
+        self._chunk_size = chunk_size
+        self._do_request()
+
+        try:
+            self._content_length = int(self._resp.getheader("Content-Length"))
+        except TypeError:
+            self._content_length = None
+
+        self._seekable = self._resp.getheader("Accept-Ranges", "").lower() == "bytes"
+
+    def _reset(self):
+        if self._resp:
+            # release the connection back into the pool
+            self._resp.release_conn()
+        self._resp = None
+        self._buff.reset()
+
+    def _do_request(self, start=0):
+        self._reset()
+
+        headers = {}
+        if start > 0:
+            headers["Range"] = "bytes={}-".format(start)
+
+        resp = self._pool.request(
+            "GET",
+            self._url,
+            headers=headers,
+            preload_content=False,
+        )
+        if start > 0 and self._content_length is None and resp.status == 416:
+            # Hit the end of the file - no more data
+            self._reset()
+        elif resp.status not in (200, 206):
+            self._reset()
+            raise urllib3.exceptions.HTTPError(
+                "Bad status code: {}".format(resp.status)
+            )
+        else:
+            self._resp = resp
+            self._buff.reset(resp.stream(amt=self._chunk_size, decode_content=True))
+
+    def __len__(self):
+        if self._content_length is None:
+            raise TypeError("The length of this {} is unknown".format(self.__class__.__name__))
+        return self._content_length
+
+    def close(self):
+        self._reset()
+        super().close()
+
+    def writable(self):
+        return False
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return self._seekable
+
+    def tell(self):
+        return self._pos
+
+    def detach(self):
+        raise io.UnsupportedOperation()
+
+    def read(self, size=-1):
+        ret = self._buff.read(size)
+        self._pos += len(ret)
+        return ret
+
+    def read1(self, size=-1):
+        ret = self._buff.read1(size)
+        self._pos += len(ret)
+        return ret
+
+    def readinto(self, b):
+        data = self.read(len(b))
+        l = len(data)
+        b[:l] = data
+        return l
+
+    def readinto1(self, b):
+        data = self.read1(len(b))
+        l = len(data)
+        b[:l] = data
+        return l
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if not self.seekable():
+            raise io.UnsupportedOperation(f"URL '{self._url}' does not support range requests")
+
+        if whence == io.SEEK_SET:
+            new_pos = offset
+        elif whence == io.SEEK_CUR:
+            new_pos = self._pos + offset
+        elif whence == io.SEEK_END:
+            if self._content_length is None:
+                raise io.UnsupportedOperation("can't do end-relative seeks without knowing the length")
+            new_pos = len(self) + offset
+        else:
+            raise ValueError("Invalid whence: {}".format(whence))
+
+        if self._content_length is not None:
+            new_pos = min(new_pos, self._content_length)
+        new_pos = max(0, new_pos)
+
+        if new_pos == self._content_length:
+            # seeking to end - no more data
+            self._reset()
+        else:
+            # Figure out how far off we are and seek within the buffered data
+            # to get as close as possible to the target offset
+            pos_diff = new_pos - self._pos
+            pos_diff -= self._buff.relseek(pos_diff)
+
+            if pos_diff == 0:
+                # seeked to an already-buffered offset - nothing else to do
+                pass
+            elif 0 < pos_diff < self._chunk_size * 2:
+                # seeking forwards and we're close enough (within 2 iterations of
+                # the current request) that it makes sense to avoid doing another
+                # fresh HTTP request - read the data until we get to the target
+                # offset
+                self.read(pos_diff)
+            else:
+                # seekable stream and we're before the current position or far
+                # enough ahead that we don't want to read everything up to it - do
+                # a range request starting at the requested offset
+                self._do_request(new_pos)
+
+        self._pos = new_pos
+        return self._pos
 
 
 def emoji_replace(s, emoji_map):
@@ -372,7 +602,7 @@ def file_upload_attempts(data):
 
         try:
             f = discord.File(
-                fp=io.BytesIO(urllib.request.urlopen(url).read()),
+                fp=SeekableHTTPStream(url),
                 filename=filename
             )
         except Exception:

--- a/slack_to_discord/__init__.py
+++ b/slack_to_discord/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+from slack_to_discord.importer import run_import
+from slack_to_discord.http_stream import SeekableHTTPStream

--- a/slack_to_discord/__main__.py
+++ b/slack_to_discord/__main__.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+from discord.utils import setup_logging
+
+from slack_to_discord import run_import
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Import Slack chat history into Discord"
+    )
+    parser.add_argument("-z", "--zipfile", help="The Slack export zip file", required=True)
+    parser.add_argument("-g", "--guild", help="The Discord Guild to import history into", required=True)
+    parser.add_argument("-t", "--token", help="The Discord bot token", required=True)
+    parser.add_argument("-s", "--start", help="The date to start importing from", required=False, default=None)
+    parser.add_argument("-e", "--end", help="The date to end importing at", required=False, default=None)
+    parser.add_argument("-p", "--all-private", help="Import all channels as private channels in Discord", action="store_true", default=False)
+    parser.add_argument("-r", "--real-names", help="Use real names from Slack instead of usernames", action="store_true", default=False)
+    parser.add_argument("-v", "--verbose", help="Show more verbose logs", action="store_true")
+    args = parser.parse_args()
+
+    setup_logging(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    run_import(
+        zipfile=args.zipfile,
+        token=args.token,
+        guild_name=args.guild,
+        all_private=args.all_private,
+        real_names=args.real_names,
+        start=args.start,
+        end=args.end
+    )
+
+if __name__ == "__main__":
+    main()

--- a/slack_to_discord/http_stream.py
+++ b/slack_to_discord/http_stream.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+
+import io
+
+import urllib3
+
+
+class IterBuffer:
+    """Provides a buffered readable interface for an iterator"""
+
+    def __init__(self, iterator=None):
+        self.reset(iterator)
+
+    def __len__(self):
+        """How much data is available to be read from the buffer"""
+        return len(self._data) - self._pos
+
+    def _buff_read(self, size=-1):
+        l = len(self)
+        if size < 0 or size > l:
+            size = l
+        if size < 1:
+            return b""
+
+        ret = bytes(self._data if size == l else self._data[self._pos:self._pos+size])
+        self._pos += size
+        return ret
+
+    def _buff_fill(self, size, read1=False):
+        """Ensure enough data is in the buffer"""
+        if size == 0 or self._iter is None:
+            return
+
+        cur_size = len(self)
+        if size > 0 and cur_size >= size:
+            # have the data, don't need to read anything
+            return
+
+        if self._pos > 0:
+            self._data = self._data[self._pos:]
+            self._pos = 0
+
+        for x in self._iter:
+            self._data += x
+            cur_size += len(x)
+            if read1 or (size > 0 and cur_size >= size):
+                break
+        else:
+            self._iter = None
+
+    def relseek(self, num):
+        """Relative seek within the buffer
+
+        Given the number of bytes to seek within the buffer (-/+), get as close
+        as possible and return the actual seek amount
+        """
+        actual = max(-self._pos, min(num, len(self)))
+        self._pos += actual
+        return actual
+
+    def read(self, size=-1):
+        """Read and return up to `size` bytes.
+
+        If the argument is omitted or negative, data is read and returned until
+        EOF is reached. An empty bytes object is returned if the stream is
+        already at EOF
+        """
+        self._buff_fill(size)
+        return self._buff_read(size)
+
+    def read1(self, size=-1):
+        """Read and return up to `size` bytes with at most one call to the iterator"""
+        self._buff_fill(size, read1=True)
+        return self._buff_read(size)
+
+    def reset(self, iterator=None):
+        """Zero out the current buffer and assign a new iterator to buffer bytes from"""
+        self._iter = iterator
+        self._data = bytearray()
+        self._pos = 0
+
+
+class SeekableHTTPStream(io.BufferedIOBase):
+    """Make the contents at a URL addressable via a seekable file-like object.
+
+    Seeking to arbitrary offsets is handled using HTTP range requests.
+
+    Notes:
+     - The server must respond with an `Accept-Ranges: bytes` header for seeking to be supported.
+     - Using `__len__` or `io.SEEK_END` to seek requires the server to have sent a valid `Content-Length` header.
+    """
+
+    def __init__(self, url, chunk_size=64*1024):
+        self._pos = 0
+        self._url = url
+        self._pool = urllib3.PoolManager()
+        self._resp = None
+        self._buff = IterBuffer()
+
+        self._chunk_size = chunk_size
+        self._do_request()
+
+        try:
+            self._content_length = int(self._resp.getheader("Content-Length"))
+        except TypeError:
+            self._content_length = None
+
+        self._seekable = self._resp.getheader("Accept-Ranges", "").lower() == "bytes"
+
+    def _reset(self):
+        if self._resp:
+            # release the connection back into the pool
+            self._resp.release_conn()
+        self._resp = None
+        self._buff.reset()
+
+    def _do_request(self, start=0):
+        self._reset()
+
+        headers = {}
+        if start > 0:
+            headers["Range"] = "bytes={}-".format(start)
+
+        resp = self._pool.request(
+            "GET",
+            self._url,
+            headers=headers,
+            preload_content=False,
+        )
+        if start > 0 and self._content_length is None and resp.status == 416:
+            # Hit the end of the file - no more data
+            self._reset()
+        elif resp.status not in (200, 206):
+            self._reset()
+            raise urllib3.exceptions.HTTPError(
+                "Bad status code: {}".format(resp.status)
+            )
+        else:
+            self._resp = resp
+            self._buff.reset(resp.stream(amt=self._chunk_size, decode_content=True))
+
+    def __len__(self):
+        if self._content_length is None:
+            raise TypeError("The length of this {} is unknown".format(self.__class__.__name__))
+        return self._content_length
+
+    def close(self):
+        self._reset()
+        super().close()
+
+    def writable(self):
+        return False
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return self._seekable
+
+    def tell(self):
+        return self._pos
+
+    def detach(self):
+        raise io.UnsupportedOperation()
+
+    def read(self, size=-1):
+        ret = self._buff.read(size)
+        self._pos += len(ret)
+        return ret
+
+    def read1(self, size=-1):
+        ret = self._buff.read1(size)
+        self._pos += len(ret)
+        return ret
+
+    def readinto(self, b):
+        data = self.read(len(b))
+        l = len(data)
+        b[:l] = data
+        return l
+
+    def readinto1(self, b):
+        data = self.read1(len(b))
+        l = len(data)
+        b[:l] = data
+        return l
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        if not self.seekable():
+            raise io.UnsupportedOperation(f"URL '{self._url}' does not support range requests")
+
+        if whence == io.SEEK_SET:
+            new_pos = offset
+        elif whence == io.SEEK_CUR:
+            new_pos = self._pos + offset
+        elif whence == io.SEEK_END:
+            if self._content_length is None:
+                raise io.UnsupportedOperation("can't do end-relative seeks without knowing the length")
+            new_pos = len(self) + offset
+        else:
+            raise ValueError("Invalid whence: {}".format(whence))
+
+        if self._content_length is not None:
+            new_pos = min(new_pos, self._content_length)
+        new_pos = max(0, new_pos)
+
+        if new_pos == self._content_length:
+            # seeking to end - no more data
+            self._reset()
+        else:
+            # Figure out how far off we are and seek within the buffered data
+            # to get as close as possible to the target offset
+            pos_diff = new_pos - self._pos
+            pos_diff -= self._buff.relseek(pos_diff)
+
+            if pos_diff == 0:
+                # seeked to an already-buffered offset - nothing else to do
+                pass
+            elif 0 < pos_diff < self._chunk_size * 2:
+                # seeking forwards and we're close enough (within 2 iterations of
+                # the current request) that it makes sense to avoid doing another
+                # fresh HTTP request - read the data until we get to the target
+                # offset
+                self.read(pos_diff)
+            else:
+                # seekable stream and we're before the current position or far
+                # enough ahead that we don't want to read everything up to it - do
+                # a range request starting at the requested offset
+                self._do_request(new_pos)
+
+        self._pos = new_pos
+        return self._pos

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -1,25 +1,23 @@
-#1/usr/bin/env python
+#!/usr/bin/env python
 
-import argparse
 import contextlib
 import functools
 import glob
 import html
-import io
 import json
 import logging
 import os
 import re
 import tempfile
 import textwrap
-import urllib
 from zipfile import ZipFile
 from datetime import datetime
 from urllib.parse import urlparse
 
 import discord
 from discord.errors import Forbidden
-import urllib3
+
+from slack_to_discord.http_stream import SeekableHTTPStream
 
 
 # Discord size limits
@@ -70,235 +68,6 @@ GLOBAL_EMOJI_MAP = {
 
 
 __log__ = logging.getLogger(__name__)
-
-
-class IterBuffer:
-    """Provides a buffered readable interface for an iterator"""
-
-    def __init__(self, iterator=None):
-        self.reset(iterator)
-
-    def __len__(self):
-        """How much data is available to be read from the buffer"""
-        return len(self._data) - self._pos
-
-    def _buff_read(self, size=-1):
-        l = len(self)
-        if size < 0 or size > l:
-            size = l
-        if size < 1:
-            return b""
-
-        ret = bytes(self._data if size == l else self._data[self._pos:self._pos+size])
-        self._pos += size
-        return ret
-
-    def _buff_fill(self, size, read1=False):
-        """Ensure enough data is in the buffer"""
-        if size == 0 or self._iter is None:
-            return
-
-        cur_size = len(self)
-        if size > 0 and cur_size >= size:
-            # have the data, don't need to read anything
-            return
-
-        if self._pos > 0:
-            self._data = self._data[self._pos:]
-            self._pos = 0
-
-        for x in self._iter:
-            self._data += x
-            cur_size += len(x)
-            if read1 or (size > 0 and cur_size >= size):
-                break
-        else:
-            self._iter = None
-
-        return
-
-    def relseek(self, num):
-        """Relative seek within the buffer
-
-        Given the number of bytes to seek within the buffer (-/+), get as close
-        as possible and return the actual seek amount
-        """
-        actual = max(-self._pos, min(num, len(self)))
-        self._pos += actual
-        return actual
-
-    def read(self, size=-1):
-        """Read and return up to `size` bytes.
-
-        If the argument is omitted or negative, data is read and returned until
-        EOF is reached. An empty bytes object is returned if the stream is
-        already at EOF
-        """
-        self._buff_fill(size)
-        return self._buff_read(size)
-
-    def read1(self, size=-1):
-        """Read and return up to `size` bytes with at most one call to the iterator"""
-        self._buff_fill(size, read1=True)
-        return self._buff_read(size)
-
-    def reset(self, iterator=None):
-        """Zero out the current buffer and assign a new iterator to buffer bytes from"""
-        self._iter = iterator
-        self._data = bytearray()
-        self._pos = 0
-
-
-class SeekableHTTPStream(io.BufferedIOBase):
-    """Make the contents at a URL addressable via a seekable file-like object.
-
-    Seeking to arbitrary offsets is handled using HTTP range requests.
-
-    Notes:
-     - The server must respond with an `Accept-Ranges: bytes` header for seeking to be supported.
-     - Using `__len__` or `io.SEEK_END` to seek requires the server to have sent a valid `Content-Length` header.
-    """
-
-    def __init__(self, url, chunk_size=64*1024):
-        self._pos = 0
-        self._url = url
-        self._pool = urllib3.PoolManager()
-        self._resp = None
-        self._buff = IterBuffer()
-
-        self._chunk_size = chunk_size
-        self._do_request()
-
-        try:
-            self._content_length = int(self._resp.getheader("Content-Length"))
-        except TypeError:
-            self._content_length = None
-
-        self._seekable = self._resp.getheader("Accept-Ranges", "").lower() == "bytes"
-
-    def _reset(self):
-        if self._resp:
-            # release the connection back into the pool
-            self._resp.release_conn()
-        self._resp = None
-        self._buff.reset()
-
-    def _do_request(self, start=0):
-        self._reset()
-
-        headers = {}
-        if start > 0:
-            headers["Range"] = "bytes={}-".format(start)
-
-        resp = self._pool.request(
-            "GET",
-            self._url,
-            headers=headers,
-            preload_content=False,
-        )
-        if start > 0 and self._content_length is None and resp.status == 416:
-            # Hit the end of the file - no more data
-            self._reset()
-        elif resp.status not in (200, 206):
-            self._reset()
-            raise urllib3.exceptions.HTTPError(
-                "Bad status code: {}".format(resp.status)
-            )
-        else:
-            self._resp = resp
-            self._buff.reset(resp.stream(amt=self._chunk_size, decode_content=True))
-
-    def __len__(self):
-        if self._content_length is None:
-            raise TypeError("The length of this {} is unknown".format(self.__class__.__name__))
-        return self._content_length
-
-    def close(self):
-        self._reset()
-        super().close()
-
-    def writable(self):
-        return False
-
-    def readable(self):
-        return True
-
-    def seekable(self):
-        return self._seekable
-
-    def tell(self):
-        return self._pos
-
-    def detach(self):
-        raise io.UnsupportedOperation()
-
-    def read(self, size=-1):
-        ret = self._buff.read(size)
-        self._pos += len(ret)
-        return ret
-
-    def read1(self, size=-1):
-        ret = self._buff.read1(size)
-        self._pos += len(ret)
-        return ret
-
-    def readinto(self, b):
-        data = self.read(len(b))
-        l = len(data)
-        b[:l] = data
-        return l
-
-    def readinto1(self, b):
-        data = self.read1(len(b))
-        l = len(data)
-        b[:l] = data
-        return l
-
-    def seek(self, offset, whence=io.SEEK_SET):
-        if not self.seekable():
-            raise io.UnsupportedOperation(f"URL '{self._url}' does not support range requests")
-
-        if whence == io.SEEK_SET:
-            new_pos = offset
-        elif whence == io.SEEK_CUR:
-            new_pos = self._pos + offset
-        elif whence == io.SEEK_END:
-            if self._content_length is None:
-                raise io.UnsupportedOperation("can't do end-relative seeks without knowing the length")
-            new_pos = len(self) + offset
-        else:
-            raise ValueError("Invalid whence: {}".format(whence))
-
-        if self._content_length is not None:
-            new_pos = min(new_pos, self._content_length)
-        new_pos = max(0, new_pos)
-
-        if new_pos == self._content_length:
-            # seeking to end - no more data
-            self._reset()
-        else:
-            # Figure out how far off we are and seek within the buffered data
-            # to get as close as possible to the target offset
-            pos_diff = new_pos - self._pos
-            pos_diff -= self._buff.relseek(pos_diff)
-
-            if pos_diff == 0:
-                # seeked to an already-buffered offset - nothing else to do
-                pass
-            elif 0 < pos_diff < self._chunk_size * 2:
-                # seeking forwards and we're close enough (within 2 iterations of
-                # the current request) that it makes sense to avoid doing another
-                # fresh HTTP request - read the data until we get to the target
-                # offset
-                self.read(pos_diff)
-            else:
-                # seekable stream and we're before the current position or far
-                # enough ahead that we don't want to read everything up to it - do
-                # a range request starting at the requested offset
-                self._do_request(new_pos)
-
-        self._pos = new_pos
-        return self._pos
 
 
 def emoji_replace(s, emoji_map):
@@ -808,33 +577,3 @@ def run_import(*, zipfile, token, **kwargs):
         client.run(token, reconnect=False, log_handler=None)
         if client._exception:
             raise client._exception
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="Import Slack chat history into Discord"
-    )
-    parser.add_argument("-z", "--zipfile", help="The Slack export zip file", required=True)
-    parser.add_argument("-g", "--guild", help="The Discord Guild to import history into", required=True)
-    parser.add_argument("-t", "--token", help="The Discord bot token", required=True)
-    parser.add_argument("-s", "--start", help="The date to start importing from", required=False, default=None)
-    parser.add_argument("-e", "--end", help="The date to end importing at", required=False, default=None)
-    parser.add_argument("-p", "--all-private", help="Import all channels as private channels in Discord", action="store_true", default=False)
-    parser.add_argument("-r", "--real-names", help="Use real names from Slack instead of usernames", action="store_true", default=False)
-    parser.add_argument("-v", "--verbose", help="Show more verbose logs", action="store_true")
-    args = parser.parse_args()
-
-    discord.utils.setup_logging(level=logging.DEBUG if args.verbose else logging.INFO)
-
-    run_import(
-        zipfile=args.zipfile,
-        token=args.token,
-        guild_name=args.guild,
-        all_private=args.all_private,
-        real_names=args.real_names,
-        start=args.start,
-        end=args.end
-    )
-
-if __name__ == "__main__":
-    main()

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+from http import HTTPStatus
+import http.server
+import io
+import threading
+
+import pytest
+
+from slack_to_discord import SeekableHTTPStream
+
+
+RESP_SIZE = 100
+
+
+# TODO: make tests for non-seekable and/or unknown length responses
+
+def gen_bytes(s, e):
+    return b"".join(bytes([x]) for x in range(s, e))
+
+
+class HTTPRangeRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        range_ = self.headers.get("Range")
+        start, end = 0, RESP_SIZE
+        if range_ is not None:
+            _, r = range_.split("bytes=", 1)
+            s, e = r.split("-", 1)
+            if e:
+                end = int(e)
+            if s:
+                start = int(s)
+
+            if not 0 <= start < end <= RESP_SIZE:
+                self.send_response(HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                self.end_headers()
+                return
+            else:
+                self.send_response(HTTPStatus.PARTIAL_CONTENT)
+                self.send_header("Content-Range", f"bytes {start}-{end-1}/{end}")
+        else:
+            self.send_response(HTTPStatus.OK)
+
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Content-Length", RESP_SIZE)
+        self.end_headers()
+        self.wfile.write(gen_bytes(start, end))
+
+
+@pytest.fixture(scope="module")
+def mockserver():
+    s = http.server.HTTPServer(("127.0.0.1", 0), HTTPRangeRequestHandler)
+    thread = threading.Thread(target=s.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{s.server_port}"
+    finally:
+        s.shutdown()
+        thread.join()
+
+
+def test_server(mockserver):
+    s = SeekableHTTPStream(mockserver, chunk_size=10)
+
+    assert len(s) == RESP_SIZE
+
+    # test reading chunks
+    assert s.read(10) == gen_bytes(0, 10)
+    assert s.read(10) == gen_bytes(10, 20)
+    assert s.read(10) == gen_bytes(20, 30)
+
+    # test seeking
+    assert s.seek(10, io.SEEK_CUR) == 40
+    assert s.seek(-10, io.SEEK_CUR) == 30
+    assert s.seek(0, io.SEEK_END) == RESP_SIZE
+    assert s.seek(-10, io.SEEK_END) == RESP_SIZE - 10
+    assert s.seek(5, io.SEEK_SET) == 5
+
+    # test reading across chunks
+    assert s.read(10) == gen_bytes(5, 15)
+    assert s.tell() == 15
+
+    # test seeking bck from current pos and getting data we just got just reads
+    # it from the buffer
+    assert s.seek(-10, io.SEEK_CUR) == 5
+    assert s.read(10) == gen_bytes(5, 15)
+
+    # test seeking past the end stops at the end and returns no data
+    assert s.seek(RESP_SIZE * 2) == RESP_SIZE
+    assert s.read() == b""
+
+    # test read with no args gets everything
+    assert s.seek(50) == 50
+    assert s.read() == gen_bytes(50, 100)
+
+    # test read1 only reads at most 1 chunk from the stream
+    assert s.seek(0) == 0
+    assert s.read(5) == gen_bytes(0, 5)
+    assert s.read1() == gen_bytes(5, 20) # 5 in the buff + 1 read of 10 bytes
+
+    # test readinto
+    b = bytearray(20)
+    assert s.seek(5) == 5
+    assert s.readinto(b) == 20
+    assert s.tell() == 25
+    assert bytes(b) == gen_bytes(5, 25)
+
+    # test readinto1 (partial read)
+    b = bytearray(20)
+    assert s.readinto1(b) == 15
+    assert bytes(b) == gen_bytes(25, 40) + bytes(5)


### PR DESCRIPTION
Previously, when importing Slack files into Discord, the file was fully downloaded from Slack into memory, then uploaded to Discord. This not only could use a ton of memory for large files, but because the download blocks the event loop, the program would stop being able to respond to the Discord heartbeat requests while the file was being downloaded.

This commit adds a shim that dynamically downloads chunks of data from Slack as the bot attempts to upload them to Discord. This means that only a small buffer of data has to be stored in memory at a time, as well as doesn't block the event loop for as long since it's only downloading a small chunk of data before allowing the event loop to continue.

Fixes #15