### PR TITLE
Don't fail if "mode" doesn't exist.

### DIFF
--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -226,7 +226,7 @@ def slack_channel_messages(d, channel_name, users, emoji_map, pins):
                 file_ts_map[f["id"]] = ts
 
             # Ignore tombstoned (removed) files and ones that don't have a URL
-            files = [x for x in files if x["mode"] != "tombstone" and x.get("url_private")]
+            files = [x for x in files if x.get("mode") != "tombstone" and x.get("url_private")]
 
             dt = datetime.fromtimestamp(float(ts))
             msg = {


### PR DESCRIPTION
Fixes `KeyError: 'mode'` errors happening on some channels.

I was getting errors like this:
```
2023-03-09 16:41:43 INFO     slack_to_discord.importer Processing channel '#bricole-picole'...
2023-03-09 16:41:43 CRITICAL slack_to_discord.importer Failed to finish import!
Traceback (most recent call last):
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 404, in on_ready
    await self._run_import(g)
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 472, in _run_import
    for msg in slack_channel_messages(self._data_dir, chan_name, self._users, emoji_map, pins):
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 228, in slack_channel_messages
    files = [x for x in files if x["mode"] != "tombstone" and x.get("url_private")]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 228, in <listcomp>
    files = [x for x in files if x["mode"] != "tombstone" and x.get("url_private")]
                                 ~^^^^^^^^
KeyError: 'mode'
2023-03-09 16:41:43 INFO     slack_to_discord.importer Bot logging out
Traceback (most recent call last):
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/bin/slack-to-discord", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/__main__.py", line 27, in main
    run_import(
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 561, in run_import
    raise client._exception
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 404, in on_ready
    await self._run_import(g)
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 472, in _run_import
    for msg in slack_channel_messages(self._data_dir, chan_name, self._users, emoji_map, pins):
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 228, in slack_channel_messages
    files = [x for x in files if x["mode"] != "tombstone" and x.get("url_private")]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tmaurin/.local/share/virtualenvs/slack-to-discord-WzhSpQSm/lib/python3.11/site-packages/slack_to_discord/importer.py", line 228, in <listcomp>
    files = [x for x in files if x["mode"] != "tombstone" and x.get("url_private")]
                                 ~^^^^^^^^
KeyError: 'mode'
```