### PR TITLE
Several bug fixes and Discord message formatting improvements

### DIFF
--- a/slack_to_discord/__main__.py
+++ b/slack_to_discord/__main__.py
@@ -19,9 +19,8 @@ def main():
     parser.add_argument("-e", "--end", help="The date to end importing at (YYYY-MM-DD)", required=False, default=None)
     parser.add_argument("-p", "--all-private", help="Import all channels as private channels in Discord", action="store_true", default=False)
     parser.add_argument("-r", "--real-names", help="Use real names from Slack instead of usernames", action="store_true", default=False)
-    parser.add_argument("-i", "--inline-dates", help="Include dates inline in messages rather than posting date-separator messages", action="store_true", default=False)
-    parser.add_argument("-df", "--date-format", help="Date format string for Discord messages (default: %%Y-%%m-%%d)", required=False, default="%Y-%m-%d")
-    parser.add_argument("-tf", "--time-format", help="Time format string for Discord messages (default: %%H:%%M)", required=False, default="%H:%M")
+    parser.add_argument("-df", "--date-format", help="Date format string for Discord message separators, or empty to disable separators (default: %%Y-%%m-%%d)", required=False, default="%Y-%m-%d")
+    parser.add_argument("-tf", "--time-format", help="Time format string for Discord message prefixes (default: %%H:%%M)", required=False, default="%H:%M")
     parser.add_argument("-v", "--verbose", help="Show more verbose logs", action="store_true")
     args = parser.parse_args()
 
@@ -34,7 +33,6 @@ def main():
         channels=args.channels,
         all_private=args.all_private,
         real_names=args.real_names,
-        inline_dates=args.inline_dates,
         start=args.start,
         end=args.end,
         date_format=args.date_format,

--- a/slack_to_discord/__main__.py
+++ b/slack_to_discord/__main__.py
@@ -19,6 +19,9 @@ def main():
     parser.add_argument("-e", "--end", help="The date to end importing at (YYYY-MM-DD)", required=False, default=None)
     parser.add_argument("-p", "--all-private", help="Import all channels as private channels in Discord", action="store_true", default=False)
     parser.add_argument("-r", "--real-names", help="Use real names from Slack instead of usernames", action="store_true", default=False)
+    parser.add_argument("-i", "--inline-dates", help="Include dates inline in messages rather than posting date-separator messages", action="store_true")
+    parser.add_argument("-df", "--date-format", help="Date format string for Discord messages (default: %%Y-%%m-%%d)", required=False, default="%Y-%m-%d")
+    parser.add_argument("-tf", "--time-format", help="Time format string for Discord messages (default: %%H:%%M)", required=False, default="%H:%M")
     parser.add_argument("-v", "--verbose", help="Show more verbose logs", action="store_true")
     args = parser.parse_args()
 
@@ -31,8 +34,11 @@ def main():
         channels=args.channels,
         all_private=args.all_private,
         real_names=args.real_names,
+        inline_dates=args.inline_dates,
         start=args.start,
         end=args.end,
+        date_format=args.date_format,
+        time_format=args.time_format
     )
 
 if __name__ == "__main__":

--- a/slack_to_discord/__main__.py
+++ b/slack_to_discord/__main__.py
@@ -19,7 +19,7 @@ def main():
     parser.add_argument("-e", "--end", help="The date to end importing at (YYYY-MM-DD)", required=False, default=None)
     parser.add_argument("-p", "--all-private", help="Import all channels as private channels in Discord", action="store_true", default=False)
     parser.add_argument("-r", "--real-names", help="Use real names from Slack instead of usernames", action="store_true", default=False)
-    parser.add_argument("-i", "--inline-dates", help="Include dates inline in messages rather than posting date-separator messages", action="store_true")
+    parser.add_argument("-i", "--inline-dates", help="Include dates inline in messages rather than posting date-separator messages", action="store_true", default=False)
     parser.add_argument("-df", "--date-format", help="Date format string for Discord messages (default: %%Y-%%m-%%d)", required=False, default="%Y-%m-%d")
     parser.add_argument("-tf", "--time-format", help="Time format string for Discord messages (default: %%H:%%M)", required=False, default="%H:%M")
     parser.add_argument("-v", "--verbose", help="Show more verbose logs", action="store_true")

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -99,12 +99,11 @@ def slack_usermap(d, real_names=False):
 
 
 def get_channel_name_by_id(data_dir, id):
-    for is_private, file in ((False, "channels.json"), (True, "groups.json")):
-        with contextlib.suppress(FileNotFoundError):
-            with open(os.path.join(data_dir, file), "rb") as fp:
-                for x in json.load(fp):
-                    if x["id"] == id:
-                        return x["name"]
+    with contextlib.suppress(FileNotFoundError):
+        with open(os.path.join(data_dir, "channels.json"), "rb") as fp:
+            for x in json.load(fp):
+                if x["id"] == id:
+                    return x["name"]
     return None
 
 

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -82,14 +82,17 @@ def slack_usermap(d, real_names=False):
 
     def get_userinfo(userdata):
         profile = userdata["profile"]
+        # some user profiles don't have image_original - fall back to image_512
+        avatar_url = profile.get("image_original") or profile.get("image_512")
+
         if real_names:
             name = profile["real_name_normalized"]
         else:
             # bots and some user profiles sometimes don't set a display name
             # fall back to real_name_normalized if set, otherwise internal username
             name = profile["display_name_normalized"] or profile["real_name_normalized"] or userdata["name"]
-        # some user profiles don't have image_original - fall back to image_512
-        return (name, profile.get("image_original") or profile.get("image_512"))
+
+        return (name, avatar_url)
 
 
     r = {x["id"]: get_userinfo(x) for x in data}

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -204,13 +204,13 @@ def slack_channel_messages(datadir, channel_name, users, emoji_map, pins, date_f
 
             text = MENTION_RE.sub(mention_repl, text)
             # (when replacing links, include original link text, if any)
-            text = LINK_RE.sub(lambda x: f"[{x.group(2)}]({x.group(1)})" if x.group(2) and x.group(2) != x.group(1) else x.group(1), text)
+            text = LINK_RE.sub(lambda x: "[{}]({})".format(x.group(2), x.group(1)) if x.group(2) and x.group(2) != x.group(1) else x.group(1), text)
             text = emoji_replace(text, emoji_map)
             text = html.unescape(text)
             text = text.rstrip()
 
             # Replace Slack *bold* text with proper Markdown **bold** text, as used in Discord
-            text = ITALICS_STARRED_RE.sub(lambda x: f"**{x.group(1)}**", text)
+            text = ITALICS_STARRED_RE.sub(lambda x: "**{}**".format(x.group(1)), text)
             # Replace Slack-style bulleted lists (tab=4) with Discord-style bulleted lists (tab=2)
             text = BULLET_RE.sub("-", text)
             text = INITIAL_SPACE_RE.sub(lambda x: x.group(1), text)
@@ -391,7 +391,7 @@ def file_upload_attempts(data, channel_dir):
     attachments_dir = os.path.join(channel_dir, 'attachments')
     attachment_path = os.path.join(
         attachments_dir,
-        f"{fd["url"].split("/")[-2].split("-")[-1]}-{fd["name"]}"
+        "{}-{}".format(fd["url"].split("/")[-2].split("-")[-1], fd["name"])
     )
     if os.path.exists(attachment_path):
         try:

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -201,8 +201,6 @@ def slack_channel_messages(datadir, channel_name, users, emoji_map, pins, date_f
             # Note that some messages have no "text" field
             # (e.g. messages with only an image/attachment)
             text = d["text"] if "text" in d else ""
-            
-            __log__.info("Raw text: %s", text)
 
             text = MENTION_RE.sub(mention_repl, text)
             # (when replacing links, include original link text, if any)
@@ -219,8 +217,6 @@ def slack_channel_messages(datadir, channel_name, users, emoji_map, pins, date_f
             text = UNICODE_VARIATION_SELECTOR_RE.sub("", text) # also, remove variation-selector control chars because they can mess up list formatting
             # Discord renders empty lines within quote blocks weirdly, so add a space to them
             text = EMPTY_QUOTE_LINE_RE.sub('> \n', text)
-            
-            __log__.info("Formatted text: %s", text)
             
             ts = d["ts"]
 

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -445,7 +445,7 @@ class SlackImportClient(discord.Client):
         self._channels = channels or None
         self._all_private = all_private
         self._date_format, self._time_format = date_format, time_format
-        self._start, self._end = [datetime.strptime(x, date_format).date() if x else None for x in (start, end)]
+        self._start, self._end = [datetime.strptime(x, "%Y-%m-%d").date() if x else None for x in (start, end)]
 
         self._users = slack_usermap(data_dir, real_names=real_names)
 

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -33,7 +33,6 @@ ATTACHMENT_ERROR_APPEND = "\n<original file not uploaded due to size restriction
 
 # Create a separator between dates? (None for no)
 DATE_SEPARATOR = "`{:-^30}`"
-DATE_FORMAT_FOR_SEPARATOR = " %B %-d, %Y "
 
 MENTION_RE = re.compile(r"<([@!#])([^>]*?)(?:\|([^>]*?))?>")
 LINK_RE = re.compile(r"<((?:https?|mailto|tel):[A-Za-z0-9_\+\.\-\/\?\,\=\#\:\@\(\)]+)\|([^>]+)>")
@@ -204,7 +203,7 @@ def slack_channel_messages(datadir, channel_name, users, emoji_map, pins, date_f
 
             text = MENTION_RE.sub(mention_repl, text)
             # (when replacing links, include original link text, if any)
-            text = LINK_RE.sub(lambda x: f"[{x.group(2)}]({x.group(1)})" if x.group(2) else x.group(1), text)
+            text = LINK_RE.sub(lambda x: f"[{x.group(2)}]({x.group(1)})" if x.group(2) and x.group(2) != x.group(1) else x.group(1), text)
             text = emoji_replace(text, emoji_map)
             text = html.unescape(text)
             text = text.rstrip()

--- a/slack_to_discord/importer.py
+++ b/slack_to_discord/importer.py
@@ -25,12 +25,9 @@ from slack_to_discord.emojis import GLOBAL_EMOJI_MAP
 MAX_MESSAGE_SIZE = 2000
 MAX_THREADNAME_SIZE = 100
 
-# Date and time formats
-DATE_FORMAT = "%Y-%m-%d"
-TIME_FORMAT = "%H:%M"
-
 # Formatting options for messages
 MSG_FORMAT = "`{time}` {text}"
+INLINE_DATE_MSG_FORMAT = "`{date}, {time}` {text}"
 BACKUP_THREAD_NAME = "{date} {time}"  # used when the message to create the thread from has no text
 ATTACHMENT_TITLE_TEXT = "<*uploaded a file*> {title}"
 ATTACHMENT_ERROR_APPEND = "\n<original file not uploaded due to size restrictions. See original at <{url}>>"
@@ -42,6 +39,10 @@ MENTION_RE = re.compile(r"<([@!#])([^>]*?)(?:\|([^>]*?))?>")
 LINK_RE = re.compile(r"<((?:https?|mailto|tel):[A-Za-z0-9_\+\.\-\/\?\,\=\#\:\@\(\)]+)\|([^>]+)>")
 EMOJI_RE = re.compile(r":([^ /<>:]+):(?::skin-tone-(\d):)?")
 
+ITALICS_STARRED_RE = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)") # matches *italics* but not _italics_ or **bold**
+BULLET_RE = re.compile(r"[\u2022\u25AA\u25E6]") # matches the bullet points that could appear in bulleted lists in a Slack export (• ◦ and ▪︎)
+INITIAL_SPACE_RE = re.compile(r"(?<=\n)((  )+)\1") # captures half of initial spaces in a line in a capture group (to turn, e.g. groups of 4 spaces into groups of 2)
+EMPTY_QUOTE_LINE_RE = re.compile(r">\n") # matches empty lines in quote blocks
 
 
 __log__ = logging.getLogger(__name__)
@@ -84,15 +85,27 @@ def slack_usermap(d, real_names=False):
         if real_names:
             name = profile["real_name_normalized"]
         else:
-            # bots sometimes don't set a display name - fall back to the internal username
-            name = profile["display_name_normalized"] or userdata["name"]
-        return (name, profile.get("image_original"))
+            # bots and some user profiles sometimes don't set a display name
+            # fall back to real_name_normalized if set, otherwise internal username
+            name = profile["display_name_normalized"] or profile["real_name_normalized"] or userdata["name"]
+        # some user profiles don't have image_original - fall back to image_512
+        return (name, profile.get("image_original") or profile.get("image_512"))
 
 
     r = {x["id"]: get_userinfo(x) for x in data}
     r["USLACKBOT"] = ("Slackbot", None)
     r["B01"] = ("Slackbot", None)
     return r
+
+
+def get_channel_name_by_id(data_dir, id):
+    for is_private, file in ((False, "channels.json"), (True, "groups.json")):
+        with contextlib.suppress(FileNotFoundError):
+            with open(os.path.join(data_dir, file), "rb") as fp:
+                for x in json.load(fp):
+                    if x["id"] == id:
+                        return x["name"]
+    return None
 
 
 def slack_channels(d):
@@ -142,13 +155,16 @@ def slack_filedata(f):
     }
 
 
-def slack_channel_messages(datadir, channel_name, users, emoji_map, pins):
+def slack_channel_messages(datadir, channel_name, users, emoji_map, pins, date_format, time_format):
     def mention_repl(m):
         type_ = m.group(1)
         target = m.group(2)
         channel_name = m.group(3)
 
         if type_ == "#":
+            # sometimes channels mentions only have the target (channel ID) field
+            # but not the channel name field - so we must determine channel name
+            channel_name = channel_name or get_channel_name_by_id(datadir, target) or target
             return "`#{}`".format(channel_name)
         elif channel_name is not None:
             return m.group(0)
@@ -180,13 +196,25 @@ def slack_channel_messages(datadir, channel_name, users, emoji_map, pins):
         with open(file, "rb") as fp:
             data = json.load(fp)
         for d in sorted(data, key=lambda x: getkey(file, x, "ts")):
-            text = getkey(file, d, "text")
+            # Note that some messages have no "text" field
+            # (e.g. messages with only an image/attachment)
+            text = d["text"] if "text" in d else ""
+
             text = MENTION_RE.sub(mention_repl, text)
-            text = LINK_RE.sub(lambda x: x.group(1), text)
+            # (when replacing links, include original link text, if any)
+            text = LINK_RE.sub(lambda x: f"[{x.group(2)}]({x.group(1)})" if x.group(2) else x.group(1), text)
             text = emoji_replace(text, emoji_map)
             text = html.unescape(text)
             text = text.rstrip()
 
+            # Replace Slack *bold* text with proper Markdown **bold** text, as used in Discord
+            text = ITALICS_STARRED_RE.sub(lambda x: f"**{x.group(1)}**", text)
+            # Replace Slack-style bulleted lists (tab=4) with Discord-style bulleted lists (tab=2)
+            text = BULLET_RE.sub("*", text)
+            text = INITIAL_SPACE_RE.sub(lambda x: x.group(1), text)
+            # Discord renders empty lines within quote blocks weirdly, so add a space to them
+            text = EMPTY_QUOTE_LINE_RE.sub('> \n', text)
+            
             ts = d["ts"]
 
             user_id = d.get("user")
@@ -248,8 +276,8 @@ def slack_channel_messages(datadir, channel_name, users, emoji_map, pins):
             msg = {
                 "userinfo": users.get(user_id, ("[unknown]", None)),
                 "datetime": dt,
-                "time": dt.strftime(TIME_FORMAT),
-                "date": dt.strftime(DATE_FORMAT),
+                "time": dt.strftime(time_format),
+                "date": dt.strftime(date_format),
                 "text": text,
                 "replies": {},
                 "reactions": {
@@ -297,7 +325,8 @@ def mark_end(iterable):
         yield True, a
 
 
-def make_discord_msgs(msg):
+def make_discord_msgs(msg, inline_dates):
+    msg_format = INLINE_DATE_MSG_FORMAT if inline_dates else MSG_FORMAT
 
     # Show reactions listed in an embed
     embed = None
@@ -311,14 +340,14 @@ def make_discord_msgs(msg):
     # Split the text into chunks to keep it under MAX_MESSAGE_SIZE
     # Send everything except the last chunk
     content = None
-    prefix_len = len(MSG_FORMAT.format(**{**msg, "text": ""}))
+    prefix_len = len(msg_format.format(**{**msg, "text": ""}))
     for is_last, chunk in mark_end(textwrap.wrap(
         text=msg.get("text") or "",
         width=MAX_MESSAGE_SIZE - prefix_len,
         drop_whitespace=False,
         replace_whitespace=False
     )):
-        content = MSG_FORMAT.format(**{**msg, "text": chunk.strip()})
+        content = msg_format.format(**{**msg, "text": chunk.strip()})
         if not is_last:
             yield {
                 "content": content
@@ -342,20 +371,39 @@ def make_discord_msgs(msg):
     # Send one messge per image that was posted (using the picture title as the message)
     for f in msg["files"]:
         yield {
-            "content": MSG_FORMAT.format(**{**msg, "text": ATTACHMENT_TITLE_TEXT.format(**f)}),
+            "content": msg_format.format(**{**msg, "text": ATTACHMENT_TITLE_TEXT.format(**f)}),
             "file_data": f,
             "embed": embed
         }
         embed = None
 
 
-def file_upload_attempts(data):
+def file_upload_attempts(data, channel_dir):
     # Files that are too big cause issues
     # yield data to try to send (original, then thumbnails)
     fd = data.pop("file_data", None)
     if not fd:
         yield data
         return
+
+    # First check the local "attachments" folder (e.g. if we're dealing with a slackdump export)
+    attachments_dir = os.path.join(channel_dir, 'attachments')
+    attachment_path = os.path.join(
+        attachments_dir,
+        f"{fd["url"].split("/")[-2].split("-")[-1]}-{fd["name"]}"
+    )
+    if os.path.exists(attachment_path):
+        try:
+            __log__.info("Uploading %s", attachment_path)
+            f = discord.File(fp=attachment_path, filename=fd["name"])
+        except Exception:
+            __log__.debug("Failed to upload file", exc_info=True)
+        else:
+            yield {
+                **data,
+                "file": f
+            }
+            return
 
     for i, url in enumerate([fd["url"]] + fd.get("thumbs", [])):
         if i > 0:
@@ -389,12 +437,14 @@ def file_upload_attempts(data):
 
 class SlackImportClient(discord.Client):
 
-    def __init__(self, *args, data_dir, guild_name, channels, start, end, all_private, real_names, **kwargs):
+    def __init__(self, *args, data_dir, guild_name, channels, start, end, all_private, real_names, inline_dates, date_format, time_format, **kwargs):
         self._data_dir = data_dir
         self._guild_name = guild_name
         self._channels = channels or None
         self._all_private = all_private
-        self._start, self._end = [datetime.strptime(x, DATE_FORMAT).date() if x else None for x in (start, end)]
+        self._inline_dates = inline_dates
+        self._date_format, self._time_format = date_format, time_format
+        self._start, self._end = [datetime.strptime(x, date_format).date() if x else None for x in (start, end)]
 
         self._users = slack_usermap(data_dir, real_names=real_names)
 
@@ -440,11 +490,11 @@ class SlackImportClient(discord.Client):
                 await target.send(content=DATE_SEPARATOR.format(msg_date))
             self._prev_msg = msg
 
-    async def _send_slack_msg(self, send, msg):
+    async def _send_slack_msg(self, send, msg, channel_dir):
         sent = None
         pin = msg["events"].pop("pin", False)
-        for data in make_discord_msgs(msg):
-            for attempt in file_upload_attempts(data):
+        for data in make_discord_msgs(msg, self._inline_dates):
+            for attempt in file_upload_attempts(data, channel_dir):
                 with contextlib.suppress(Exception):
                     sent = await send(
                         username=msg["userinfo"][0],
@@ -483,6 +533,7 @@ class SlackImportClient(discord.Client):
             ch = None
             ch_webhook, ch_send = None, None
             c_msg_start = c_msg
+            channel_dir = os.path.join(self._data_dir, chan_name)
 
             self._prev_msg = None  # always start with the date in a new channel
 
@@ -490,7 +541,7 @@ class SlackImportClient(discord.Client):
 
             __log__.info("Processing channel '#%s'...", chan_name)
 
-            for msg in slack_channel_messages(self._data_dir, chan_name, self._users, emoji_map, pins):
+            for msg in slack_channel_messages(self._data_dir, chan_name, self._users, emoji_map, pins, self._date_format, self._time_format):
                 # skip messages that are too early, stop when messages are too late
                 if self._end and msg["datetime"].date() > self._end:
                     break
@@ -528,8 +579,9 @@ class SlackImportClient(discord.Client):
                     await ch.edit(topic=topic)
 
                 # Send message and threaded replies
-                await self._handle_date_sep(ch, msg)
-                sent = await self._send_slack_msg(ch_send, msg)
+                if not self._inline_dates:
+                    await self._handle_date_sep(ch, msg)
+                sent = await self._send_slack_msg(ch_send, msg, channel_dir)
                 c_msg += 1
                 if sent and msg["replies"]:
                     thread_name = (
@@ -540,8 +592,9 @@ class SlackImportClient(discord.Client):
                     try:
                         thread_send = functools.partial(ch_send, thread=thread)
                         for rmsg in msg["replies"]:
-                            await self._handle_date_sep(thread, rmsg)
-                            await self._send_slack_msg(thread_send, rmsg)
+                            if not self._inline_dates:
+                                await self._handle_date_sep(thread, rmsg)
+                            await self._send_slack_msg(thread_send, rmsg, channel_dir)
                             c_msg += 1
                     finally:
                         await thread.edit(archived=True)


### PR DESCRIPTION
While importing a large export of a Slack instance generated by [slackdump](https://github.com/rusq/slackdump), I ran into several issues. I'm making a PR containing all of my fixes in one go, but am also happy to break this up into smaller PRs if needed.

Fixes/improvements in this PR:
* Fix a critical bug that would stop import upon encountering a message with no `text` field (this can happen when, i.e. a user uploads a file with no additional text in the message)
* Retrieve attachments from the export file itself when possible (i.e. when importing a Slackdump export with attachments included)
* Fall back to `image_512` field for retrieving avatar for user profiles that don't have `image_original` defined
* Fall back to `real_name_normalized` field before internal username for user profiles that don't have `display_name_normalized` defined (I've found that `real_name_normalized` tends to match `display_name_normalized` closer than the internal username does)
* Correctly handle `#channel` links that only have channel ID rather than name
* Include link text in hyperlinks when it is present
* Replace Slack-style `*bold*` text blocks with Discord Markdown `**bold**` text
* Handle nested bulleted lists correctly by converting the Slack format to Discord format
* Render Slack quote blocks better in Discord by including extra spaces when necessary
* Customizable date and time formats via CLI flags